### PR TITLE
Remove dependency on sentencepiece

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description="A Neural Language Style Transfer framework to transfer natural language text smoothly between fine-grained language styles like formal/casual, active/passive, and many more. Created by Prithiviraj Damodaran. Open to pull requests and other forms of collaboration.",
     url="https://github.com/PrithivirajDamodaran/Styleformer.git",
     packages=setuptools.find_packages(),
-    install_requires=['transformers', 'sentencepiece', 'python-Levenshtein', 'fuzzywuzzy'],
+    install_requires=['transformers', 'python-Levenshtein', 'fuzzywuzzy'],
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "License :: Apache 2.0",


### PR DESCRIPTION
As far as I can tell, there's NO mention of sentencepiece in Styleformer so it's not needed.  More importantly it causes a known [fatal installation error](https://github.com/google/sentencepiece/issues/452) for some Windows users when using PIP.